### PR TITLE
Fix eim-gui cask: set version to 0.7.1 (EIM-478)

### DIFF
--- a/Casks/eim-gui.rb
+++ b/Casks/eim-gui.rb
@@ -1,5 +1,5 @@
 cask "eim-gui" do
-  version ""
+  version "0.7.1"
 
   on_intel do
     url "https://github.com/espressif/idf-im-ui/releases/download/v0.7.1/eim-gui-macos-x64.dmg"


### PR DESCRIPTION
This PR fixes broken eim-gui cask
```
 ~  brew install --cask eim-gui                                                                                                                 ✔  5s  00:06:08

==> Caveats
ESP-IDF Installation Manager (EIM) has been installed.

IMPORTANT: ESP-IDF requires Python 3.9, 3.10, 3.11, 3.12, or 3.13.
Python 3.14+ is not yet supported.

If you don't have a compatible Python version, install one with:
  brew install python@3.12

For QEMU emulation support, you may also need:
  brew install libgcrypt glib pixman sdl2 libslirp dfu-util

Error: Version must not be empty
Warning: Removed Sorbet lines from backtrace!
Rerun with `--verbose` to see the original backtrace
/opt/homebrew/Library/Homebrew/version.rb:499:in 'Version#initialize'
/opt/homebrew/Library/Homebrew/cask/download.rb:43:in 'Class#new'
/opt/homebrew/Library/Homebrew/cask/download.rb:43:in 'Cask::Download#version'
/opt/homebrew/Library/Homebrew/cask/download.rb:143:in 'Cask::Download#download_name'
/opt/homebrew/Library/Homebrew/downloadable.rb:125:in 'Downloadable#downloader'
/opt/homebrew/Library/Homebrew/downloadable.rb:144:in 'Downloadable#fetch'
/opt/homebrew/Library/Homebrew/cask/download.rb:57:in 'Cask::Download#fetch'
/opt/homebrew/Library/Homebrew/cask/installer.rb:249:in 'Cask::Installer#download'
/opt/homebrew/Library/Homebrew/cask/installer.rb:121:in 'Cask::Installer#fetch'
/opt/homebrew/Library/Homebrew/cask/installer.rb:153:in 'Cask::Installer#install'
/opt/homebrew/Library/Homebrew/cmd/install.rb:291:in 'block in Homebrew::Cmd::InstallCmd#run'
/opt/homebrew/Library/Homebrew/cmd/install.rb:280:in 'Array#each'
/opt/homebrew/Library/Homebrew/cmd/install.rb:280:in 'Homebrew::Cmd::InstallCmd#run'
/opt/homebrew/Library/Homebrew/brew.rb:102:in '<main>'
Please report this issue:
  https://docs.brew.sh/Troubleshooting
```